### PR TITLE
Orb changelog / diff module

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,14 +5,13 @@ jobs:
       - image: circleci/python:3.7.3
     steps:
     - checkout
-    - run: pwd
     - restore_cache:
        keys:
          - requirements-{{ checksum "requirements.txt" }}
          - requirements- # used if checksum fails
     - run: python3 -m venv venv
     - run: source venv/bin/activate
-    - run: pip install --user -r requirements.txt
+    - run: pip install -r requirements.txt
     - save_cache:
         key: requirements-{{ checksum "requirements.txt" }}
         paths:
@@ -27,7 +26,6 @@ jobs:
     steps:
       - attach_workspace:
           at: /home/circleci
-      - run: pwd
       - run: source venv/bin/activate
       - run:
           name: Run testing server for API calls

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,43 +1,18 @@
-version: 2
+version: 2.1
 jobs:
-  build:
-    docker:
-      - image: circleci/python:3.7.3
-    steps:
-    - checkout
-    - restore_cache:
-       keys:
-         - requirements-{{ checksum "requirements.txt" }}
-         - requirements- # used if checksum fails
-    - run: python3 -m venv venv
-    - run: source venv/bin/activate
-    - run: pip install -r requirements.txt
-    - save_cache:
-        key: requirements-{{ checksum "requirements.txt" }}
-        paths:
-          - venv
-    - persist_to_workspace:
-        root: /home/circleci
-        paths:
-          - project
   test:
     docker:
-      - image: circleci/python:3.7.3
+      - image: cimg/python:3.8.6
     steps:
-      - attach_workspace:
-          at: /home/circleci
-      - run: source venv/bin/activate
+      - checkout
+      - run: pipenv install -r requirements.txt
       - run:
           name: Run testing server for API calls
           command: python tests/testing-server.py
           background: true
-      - run: python main.py test
+      - run: pipenv run python main.py test
 
 workflows:
-  version: 2
   build-and-test:
     jobs:
-      - build
-      - test:
-          requires:
-            - build
+      - test

--- a/modules/orb-changes.py
+++ b/modules/orb-changes.py
@@ -1,72 +1,80 @@
 import requests
 import json
 import yaml
+from deepdiff import DeepDiff
+import deepdiff
 
-# Pass in YAML dicts.
-def parse_version_diff(version_latest, version_previous, parent="latest"):
-    diffstring = ""
-    if version_latest is None or version_previous is None:
-        return ""
+# Pass in YAML strings.
+def parse_version_diff(version_latest, version_previous):
+    ddiff = DeepDiff(version_latest, version_previous)
+    final_string = ""
 
-    for key, value in version_latest.items():
-        if value is None:
-            continue
-        if isinstance(value, list):
-            continue
-        
-        if isinstance(version_previous.get(key), type(value)) == False:
-            if version_previous.get(key) is None:
-                diffstring += "+ added {key} to {parent}\n".format(key=key, parent=parent)
-                continue
-            diffstring += "* changed {key} to {type} in {parent}\n".format(key=key, type=type(version_latest.get(key)).__name__, parent=parent)
-            continue
-        if isinstance(value, dict):
-            diffstring += parse_version_diff(value, version_previous.get(key), parent +" > {}".format(key))
-            continue
-        if version_previous.get(key) is None:
-            diffstring += "+ added {key} to {parent}\n".format(key=key, parent=parent)
-        if value != version_previous.get(key):
-            diffstring += "* changed {parent} > {key} from {from} to {to}".format(parent,key,version_previous.get(key), value)
+    for key, value in ddiff.items():
+        prefix = "?"
+        if "removed" in key:
+            prefix = "Removed"
+        if "added" in key:
+            prefix = "Added"
+        if "changed" in key or "changes" in key:
+            prefix = "Changed"
+        if isinstance(value, deepdiff.model.PrettyOrderedSet):
+            for v in value:
+                v = v.replace("root", "").replace("][", " > ").replace("[", "").replace("]", " ").replace("'", "")
+                final_string += f"{prefix}: orb > {v}  \n"
+        elif isinstance(value, dict):
+            for k, v in value.items():
+                location = k.replace("root", "").replace("][", " > ").replace("[", "").replace("]", " ").replace("'", "")
+                if v.get("diff"):
+                    diff = v.get("diff")
+                    final_string += f"{prefix}: orb > {location}\n  ```diff\n{diff}\n```  \n"
+                else:
+                    new = v.get("new_value", "")
+                    old = v.get("old_value", "")
+                    final_string += f"{prefix}: orb > {location} \"{old}\" -> \"{new}\"  \n"
 
-    for key, value in version_previous.items():
-        if isinstance(version_latest.get(key), type(value)) == False:
-            if version_latest.get(key) is None:
-                diffstring += "- removed {key} from {parent}\n".format(key=key, parent=parent)
-                continue
-            diffstring += "* changed {key} to {type} in {parent}\n".format(key=key, type=type(version_latest.get(key)).__name__, parent=parent)
-            continue
-        if isinstance(value, dict):
-            diffstring += parse_version_diff(version_latest.get(key), value, parent +" > {}".format(key))
-            continue
-        if isinstance(value, list):
-            continue
-        if value is None:
-            continue
-        if version_latest.get(key) is None:
-            diffstring += "- removed {key} from {parent}\n".format(key=key, parent=parent)
-        if value != version_latest.get(key):
-            diffstring += "* changed {parent} > {key} from {from} to {to}".format(parent,key, value, version_latest.get(key))
-
-    return diffstring
+    return final_string
 
 def run_command(args):
+    if len(args) == 2:
+        return (
+            "A latest semver was provided, but no previous.\n"
+            "Usage: ./main.py orb-changes <namespace>/<orb-name> <latest-semver> <previous-semver>"
+        )
     query = """{
-      orb(name: "circleci/slack") {
+      orb(name: "%s") {
         id
-        versions(count: 2) {
+        versions(count: 25) {
           id
           version
           source
         }
       }
-    }"""
+    }""" % (args[0])
 
     url = 'https://circleci.com/graphql-unstable'
     r = requests.post(url, json={'query': query})
     json_data = json.loads(r.text)
+    latest_version = previous_version = None
 
-    latest_version = yaml.load(json_data["data"]["orb"]["versions"][0]["source"])
-    previous_version = yaml.load(json_data["data"]["orb"]["versions"][1]["source"])
+    if len(args) == 3:
+        new = args[1]
+        old = args[2]
+        print(f"Comparing {new} to {old}")
+        for version in json_data["data"]["orb"]["versions"]:
+            if version["version"] == args[1]:
+                latest_version = yaml.load(version["source"])
+            if version["version"] == args[2]:
+                previous_version = yaml.load(version["source"])
+    else:
+        latest_version = yaml.load(json_data["data"]["orb"]["versions"][1]["source"])
+        previous_version = yaml.load(json_data["data"]["orb"]["versions"][2]["source"])
+
+    if latest_version is None or previous_version is None:
+        return (
+            "Unable to find versions to compare, exiting.\n"
+            "Note that for performance, we only fetch the last 25 versions."
+        )
 
     diff = parse_version_diff(latest_version, previous_version)
-    return diff
+    version = json_data["data"]["orb"]["versions"][1]["version"]
+    return f"## v{version}\n\n{diff}"

--- a/modules/orb-changes.py
+++ b/modules/orb-changes.py
@@ -1,0 +1,72 @@
+import requests
+import json
+import yaml
+
+# Pass in YAML dicts.
+def parse_version_diff(version_latest, version_previous, parent="latest"):
+    diffstring = ""
+    if version_latest is None or version_previous is None:
+        return ""
+
+    for key, value in version_latest.items():
+        if value is None:
+            continue
+        if isinstance(value, list):
+            continue
+        
+        if isinstance(version_previous.get(key), type(value)) == False:
+            if version_previous.get(key) is None:
+                diffstring += "+ added {key} to {parent}\n".format(key=key, parent=parent)
+                continue
+            diffstring += "* changed {key} to {type} in {parent}\n".format(key=key, type=type(version_latest.get(key)).__name__, parent=parent)
+            continue
+        if isinstance(value, dict):
+            diffstring += parse_version_diff(value, version_previous.get(key), parent +" > {}".format(key))
+            continue
+        if version_previous.get(key) is None:
+            diffstring += "+ added {key} to {parent}\n".format(key=key, parent=parent)
+        if value != version_previous.get(key):
+            diffstring += "* changed {parent} > {key} from {from} to {to}".format(parent,key,version_previous.get(key), value)
+
+    for key, value in version_previous.items():
+        if isinstance(version_latest.get(key), type(value)) == False:
+            if version_latest.get(key) is None:
+                diffstring += "- removed {key} from {parent}\n".format(key=key, parent=parent)
+                continue
+            diffstring += "* changed {key} to {type} in {parent}\n".format(key=key, type=type(version_latest.get(key)).__name__, parent=parent)
+            continue
+        if isinstance(value, dict):
+            diffstring += parse_version_diff(version_latest.get(key), value, parent +" > {}".format(key))
+            continue
+        if isinstance(value, list):
+            continue
+        if value is None:
+            continue
+        if version_latest.get(key) is None:
+            diffstring += "- removed {key} from {parent}\n".format(key=key, parent=parent)
+        if value != version_latest.get(key):
+            diffstring += "* changed {parent} > {key} from {from} to {to}".format(parent,key, value, version_latest.get(key))
+
+    return diffstring
+
+def run_command(args):
+    query = """{
+      orb(name: "circleci/slack") {
+        id
+        versions(count: 2) {
+          id
+          version
+          source
+        }
+      }
+    }"""
+
+    url = 'https://circleci.com/graphql-unstable'
+    r = requests.post(url, json={'query': query})
+    json_data = json.loads(r.text)
+
+    latest_version = yaml.load(json_data["data"]["orb"]["versions"][0]["source"])
+    previous_version = yaml.load(json_data["data"]["orb"]["versions"][1]["source"])
+
+    diff = parse_version_diff(latest_version, previous_version)
+    return diff

--- a/modules/orb-changes.py
+++ b/modules/orb-changes.py
@@ -3,6 +3,7 @@ import json
 import yaml
 from deepdiff import DeepDiff
 import deepdiff
+import sys
 
 # Pass in YAML strings.
 def parse_version_diff(version_latest, version_previous):
@@ -83,3 +84,7 @@ def run_command(args):
 
     diff = parse_version_diff(latest_version, previous_version)
     return f"## v{version}\n\n{diff}"
+
+if __name__ == '__main__':
+    result = run_command(sys.argv[1:])
+    print(result)

--- a/modules/orb-changes.py
+++ b/modules/orb-changes.py
@@ -63,11 +63,13 @@ def run_command(args):
         for version in json_data["data"]["orb"]["versions"]:
             if version["version"] == args[1]:
                 latest_version = yaml.load(version["source"])
+                version = args[1]
             if version["version"] == args[2]:
                 previous_version = yaml.load(version["source"])
     else:
-        latest_version = yaml.load(json_data["data"]["orb"]["versions"][1]["source"])
-        previous_version = yaml.load(json_data["data"]["orb"]["versions"][2]["source"])
+        latest_version = yaml.load(json_data["data"]["orb"]["versions"][0]["source"])
+        previous_version = yaml.load(json_data["data"]["orb"]["versions"][1]["source"])
+        version = json_data["data"]["orb"]["versions"][0]["version"]
 
     if latest_version is None or previous_version is None:
         return (
@@ -76,5 +78,4 @@ def run_command(args):
         )
 
     diff = parse_version_diff(latest_version, previous_version)
-    version = json_data["data"]["orb"]["versions"][1]["version"]
     return f"## v{version}\n\n{diff}"

--- a/modules/orb-changes.py
+++ b/modules/orb-changes.py
@@ -26,11 +26,11 @@ def parse_version_diff(version_latest, version_previous):
                 location = k.replace("root", "").replace("][", " > ").replace("[", "").replace("]", " ").replace("'", "")
                 if v.get("diff"):
                     diff = v.get("diff")
-                    final_string += f"{prefix}: orb > {location}\n  ```diff\n{diff}\n```  \n"
+                    final_string += f"{prefix}: orb > {location} \n```diff\n{diff}\n```  \n"
                 else:
                     new = v.get("new_value", "")
                     old = v.get("old_value", "")
-                    final_string += f"{prefix}: orb > {location} \"{old}\" -> \"{new}\"  \n"
+                    final_string += f"{prefix}: orb > {location}\"{old}\" -> \"{new}\"  \n"
 
     return final_string
 
@@ -55,17 +55,21 @@ def run_command(args):
     r = requests.post(url, json={'query': query})
     json_data = json.loads(r.text)
     latest_version = previous_version = None
+    version = ""
 
     if len(args) == 3:
         new = args[1]
         old = args[2]
         print(f"Comparing {new} to {old}")
-        for version in json_data["data"]["orb"]["versions"]:
-            if version["version"] == args[1]:
-                latest_version = yaml.load(version["source"])
-                version = args[1]
-            if version["version"] == args[2]:
-                previous_version = yaml.load(version["source"])
+        for v in json_data["data"]["orb"]["versions"]:
+            if v["version"] == new:
+                latest_version = yaml.load(v["source"])
+                version = new
+                continue
+            if v["version"] == old:
+                previous_version = yaml.load(v["source"])
+                continue
+
     else:
         latest_version = yaml.load(json_data["data"]["orb"]["versions"][0]["source"])
         previous_version = yaml.load(json_data["data"]["orb"]["versions"][1]["source"])

--- a/modules/orb-changes.py
+++ b/modules/orb-changes.py
@@ -25,9 +25,13 @@ def parse_version_diff(version_latest, version_previous):
         elif isinstance(value, dict):
             for k, v in value.items():
                 location = k.replace("root", "").replace("][", " > ").replace("[", "").replace("]", " ").replace("'", "")
+                if isinstance(v, dict) == False:
+                    final_string += f"{prefix}: orb > {location} {v}  \n"
+                    continue
                 if v.get("diff"):
                     diff = v.get("diff")
                     final_string += f"{prefix}: orb > {location} \n```diff\n{diff}\n```  \n"
+                    continue
                 else:
                     new = v.get("new_value", "")
                     old = v.get("old_value", "")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests==2.21.0
 pyyaml==3.13
+deepdiff==5.0.2


### PR DESCRIPTION
Adds a new module, `orb-changes`, which can compare the diff between two version of an orb and output a relatively readable changelog.

Samples: https://gist.github.com/gmemstr/5aa1dee4d66f6c15d30e777539522aa2